### PR TITLE
Feat: Navbar 구현

### DIFF
--- a/src/apis/getDashboardInvitations.ts
+++ b/src/apis/getDashboardInvitations.ts
@@ -4,7 +4,7 @@ import { DashboardInvitations } from 'src/types/dashboardTypes';
 
 const getDashboardInvitations = async (
   dashboardId: string | undefined,
-  page: number
+  page?: number
 ) => {
   const { data } = await axios.get<DashboardInvitations>(
     `/dashboards/${dashboardId}/invitations`,

--- a/src/apis/getDashboardMembers.ts
+++ b/src/apis/getDashboardMembers.ts
@@ -1,15 +1,15 @@
 import axios from 'src/apis/axiosInstance';
-import { PAGENATION_SIZE } from 'src/constants/pagenation';
 import { DashboardMembers } from 'src/types/dashboardTypes';
 
 const getDashboardMembers = async (
   dashboardId: string | undefined,
-  page: number
+  page?: number,
+  size?: number
 ) => {
   const { data } = await axios.get<DashboardMembers>('/members', {
     params: {
       page,
-      size: PAGENATION_SIZE.DASHBOARD.MEMBERS,
+      size,
       dashboardId
     }
   });

--- a/src/apis/getMyInfo.tsx
+++ b/src/apis/getMyInfo.tsx
@@ -1,0 +1,7 @@
+import type { MemberData } from 'src/types/memberTypes';
+import axios from './axiosInstance';
+
+export const getMyInfo = async () => {
+  const { data } = await axios.get<MemberData>('/users/me');
+  return data;
+};

--- a/src/components/Buttons/PagenationButtons.tsx
+++ b/src/components/Buttons/PagenationButtons.tsx
@@ -18,7 +18,7 @@ export default function PagenationButtons({
   isSidebar
 }: PagenationButtonsProps) {
   const contatinerStyle = isSidebar
-    ? 'flex desktop:flex-row tablet:flex-col-reverse items-center desktop:gap-[1.6rem] tablet:gep-[1.4rem] gap-[1.2rem]'
+    ? 'flex tablet:flex-col-reverse items-center desktop:gap-[1.6rem] tablet:gep-[1.4rem] gap-[1.2rem]'
     : 'flex items-center tablet:gap-[1.6rem] gap-[1.2rem]';
   const buttonStyle = isSidebar
     ? 'tablet:w-[4rem] w-[2rem] tablet:h-[4rem] h-[2rem]'

--- a/src/components/Dashboard/DashboardList.tsx
+++ b/src/components/Dashboard/DashboardList.tsx
@@ -19,13 +19,15 @@ export default function DashboardList() {
       {dashboards.map((dashboard: Dashboard) => (
         <DashboardItem key={dashboard.id} dashboard={dashboard} />
       ))}
-      <PagenationButtons
-        allPage={allPage}
-        nowPage={nowPage}
-        handleBackwardButtonClick={handleBackwardButtonClick}
-        handleForwardButtonClick={handleForwardButtonClick}
-        isSidebar
-      />
+      <div className="fixed desktop:top-[65rem] tablet:top-[63rem] top-[58rem]">
+        <PagenationButtons
+          allPage={allPage}
+          nowPage={nowPage}
+          handleBackwardButtonClick={handleBackwardButtonClick}
+          handleForwardButtonClick={handleForwardButtonClick}
+          isSidebar
+        />
+      </div>
     </div>
   );
 }

--- a/src/components/EditDashboard/EditDashboardMembers.tsx
+++ b/src/components/EditDashboard/EditDashboardMembers.tsx
@@ -13,7 +13,7 @@ export default function EditDashboardMembers() {
   } = usePagenationDashboardMembers();
 
   return (
-    <section className="pt-[2.2rem] tablet:pt-[2.6rem] pb-[0.4rem] bg-white rounded-[0.8rem] desktop:w-[62rem] tablet:w-[54.4rem] mobile:w-[28.4rem] min-h-[15rem]">
+    <section className="pt-[2.2rem] tablet:pt-[2.6rem] pb-[0.4rem] bg-white rounded-[0.8rem] desktop:w-[62rem] tablet:w-[54.4rem] mobile:w-[28.4rem] tablet:h-[41.3rem] h-[35rem]">
       <div className="flex items-center justify-between tablet:px-[2.8rem] px-[2rem]">
         <h1 className="tablet:text-[2.4rem] text-[2rem] font-bold">구성원</h1>
         <PagenationButtons

--- a/src/components/EditDashboard/EditDashboardMembers.tsx
+++ b/src/components/EditDashboard/EditDashboardMembers.tsx
@@ -13,7 +13,7 @@ export default function EditDashboardMembers() {
   } = usePagenationDashboardMembers();
 
   return (
-    <section className="pt-[2.2rem] tablet:pt-[2.6rem] pb-[0.4rem] bg-white rounded-[0.8rem] desktop:w-[62rem] tablet:w-[54.4rem] mobile:w-[28.4rem] tablet:h-[41.3rem] h-[35rem]">
+    <section className="pt-[2.2rem] tablet:pt-[2.6rem] pb-[0.4rem] bg-white rounded-[0.8rem] desktop:w-[62rem] tablet:w-[54.4rem] mobile:w-[28.4rem] tablet:h-[42rem] h-[35rem]">
       <div className="flex items-center justify-between tablet:px-[2.8rem] px-[2rem]">
         <h1 className="tablet:text-[2.4rem] text-[2rem] font-bold">구성원</h1>
         <PagenationButtons

--- a/src/components/EditDashboard/InvitationSettings.tsx
+++ b/src/components/EditDashboard/InvitationSettings.tsx
@@ -18,7 +18,7 @@ export default function InvitationSettings() {
   const setModal = useSetAtom(modalAtom);
 
   return (
-    <section className="tablet:pt-[2.8rem] pt-[2.4rem] pb-[0.4rem] bg-white rounded-[0.8rem]  desktop:w-[62rem] tablet:w-[54.4rem] mobile:w-[28.4rem] tablet:h-[48.1rem] h-[41rem]">
+    <section className="tablet:pt-[2.8rem] pt-[2.4rem] pb-[0.4rem] bg-white rounded-[0.8rem]  desktop:w-[62rem] tablet:w-[54.4rem] mobile:w-[28.4rem] tablet:h-[48.5rem] h-[41rem]">
       <div className="flex items-center justify-between tablet:px-[2.8rem] px-[2rem]">
         <h1 className="tablet:text-[2.4rem] text-[2rem] font-bold">
           초대 내역

--- a/src/components/EditDashboard/InvitationSettings.tsx
+++ b/src/components/EditDashboard/InvitationSettings.tsx
@@ -18,7 +18,7 @@ export default function InvitationSettings() {
   const setModal = useSetAtom(modalAtom);
 
   return (
-    <section className="tablet:pt-[2.8rem] pt-[2.4rem] pb-[0.4rem] bg-white rounded-[0.8rem]  desktop:w-[62rem] tablet:w-[54.4rem] mobile:w-[28.4rem] tablet:min-h-[20rem] min-h-[17rem]">
+    <section className="tablet:pt-[2.8rem] pt-[2.4rem] pb-[0.4rem] bg-white rounded-[0.8rem]  desktop:w-[62rem] tablet:w-[54.4rem] mobile:w-[28.4rem] tablet:h-[48.1rem] h-[41rem]">
       <div className="flex items-center justify-between tablet:px-[2.8rem] px-[2rem]">
         <h1 className="tablet:text-[2.4rem] text-[2rem] font-bold">
           초대 내역
@@ -57,7 +57,7 @@ export default function InvitationSettings() {
           이메일
         </h2>
         {data?.invitations.length === 0 || !data ? (
-          <div className="w-[100%] text-center mt-[2.5rem] tablet:mt-0">
+          <div className="w-[100%] h-[30rem] flex justify-center items-center tablet:mt-0">
             <p>초대 내역이 없습니다.</p>
           </div>
         ) : (

--- a/src/components/EditDashboard/Lists/DashboardMemberList.tsx
+++ b/src/components/EditDashboard/Lists/DashboardMemberList.tsx
@@ -21,10 +21,11 @@ export default function DashboardMemberList({
           >
             <Profile
               size="basicSize"
+              border="none"
               profileImgSrc={member.profileImageUrl}
               userName={member.nickname}
             />
-            {index !== 0 ? (
+            {member.isOwner ? null : (
               <Button
                 variant="secondary"
                 type="button"
@@ -33,7 +34,7 @@ export default function DashboardMemberList({
               >
                 삭제
               </Button>
-            ) : null}
+            )}
           </div>
           {index !== members.length - 1 && (
             <svg

--- a/src/components/EditDashboard/Lists/DashboardMemberList.tsx
+++ b/src/components/EditDashboard/Lists/DashboardMemberList.tsx
@@ -1,5 +1,6 @@
 import Profile from 'src/components/Profile/Profile';
 import Button from 'src/components/Buttons/Button';
+import crown from 'src/assets/images/crown.svg';
 import { DashboardMember } from 'src/types/dashboardTypes';
 
 interface Props {
@@ -25,7 +26,13 @@ export default function DashboardMemberList({
               profileImgSrc={member.profileImageUrl}
               userName={member.nickname}
             />
-            {member.isOwner ? null : (
+            {member.isOwner ? (
+              <img
+                src={crown}
+                alt="왕관 아이콘"
+                className="tablet:w-[4rem] tablet:h-[4rem] tablet:mr-[2rem] w-[3rem] h-[3rem] mr-[0.5rem]"
+              />
+            ) : (
               <Button
                 variant="secondary"
                 type="button"

--- a/src/components/Landing/OtherSections.tsx
+++ b/src/components/Landing/OtherSections.tsx
@@ -8,8 +8,8 @@ export default function OtherSections() {
       <h1 className="desktop:text-start text-center tablet:text-[2.8rem] text-[2.2rem] font-bold">
         생산성을 높이는 다양한 설정 ⚡️
       </h1>
-      <div className="flex flex-col items-center desktop:flex-row desktop:justify-between desktop:gap-[1.5rem] tablet:gap-[4.8rem] gap-[4.05rem] desktop:max-w-[120rem] desktop:min-w-[100rem] desktop:w-[calc(100vw-72rem)] w-[calc(100vw-3.2rem)]">
-        <section className="bg-black_171717 rounded-[0.8rem] w-[37.8rem] overflow-hidden">
+      <div className="flex flex-col items-center desktop:flex-row desktop:justify-between desktop:gap-[1.5rem] tablet:gap-[4.8rem] gap-[4.05rem] desktop:max-w-[120rem] desktop:min-w-[100rem] desktop:w-[calc(100vw-72rem)]">
+        <section className="bg-black_171717 rounded-[0.8rem] max-w-[37.8rem] w-[calc(100vw-3.2rem)] overflow-hidden">
           <div className="flex justify-center items-center bg-black_4B4B4B h-[26rem]">
             <img
               src={editDashboardTitle}
@@ -24,7 +24,7 @@ export default function OtherSections() {
             </p>
           </div>
         </section>
-        <section className="bg-black_171717 rounded-[0.8rem] w-[37.8rem] overflow-hidden">
+        <section className="bg-black_171717 rounded-[0.8rem] max-w-[37.8rem] w-[calc(100vw-3.2rem)] overflow-hidden">
           <div className="flex justify-center items-center bg-black_4B4B4B h-[26rem]">
             <img
               src={invitationSettins}
@@ -37,7 +37,7 @@ export default function OtherSections() {
             <p className="text-[1.6rem]">새로운 팀원을 초대할 수 있어요.</p>
           </div>
         </section>
-        <section className="bg-black_171717 rounded-[0.8rem] w-[37.8rem] overflow-hidden">
+        <section className="bg-black_171717 rounded-[0.8rem] max-w-[37.8rem] w-[calc(100vw-3.2rem)] overflow-hidden">
           <div className="flex justify-center items-center bg-black_4B4B4B h-[26rem]">
             <img
               src={editDashboardMembers}

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -7,11 +7,11 @@ export default function Layout() {
   return (
     <div className="relative flex">
       <Modal />
-      <div className="absolute top-0 left-0 z-10">
-        <Sidebar />
-      </div>
-      <div className="absolute top-0 z-5">
+      <div className="absolute top-0 z-0">
         <Navbar />
+      </div>
+      <div className="absolute top-0 left-0">
+        <Sidebar />
       </div>
       <div className="tablet:mt-[7rem] mt-[6rem] ml-[6.7rem] tablet:ml-[16rem] desktop:ml-[30rem]">
         <Outlet />

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,13 +1,21 @@
 import { Outlet } from 'react-router-dom';
 import Sidebar from './SideBarLayout';
 import Modal from './Modal';
+import Navbar from './NavbarLayout';
 
 export default function Layout() {
   return (
     <div className="relative flex">
-      <Sidebar />
       <Modal />
-      <Outlet />
+      <div className="absolute top-0 left-0 z-10">
+        <Sidebar />
+      </div>
+      <div className="absolute top-0 z-5">
+        <Navbar />
+      </div>
+      <div className="tablet:mt-[7rem] mt-[6rem] ml-[6.7rem] tablet:ml-[16rem] desktop:ml-[30rem]">
+        <Outlet />
+      </div>
     </div>
   );
 }

--- a/src/components/Layout/NavbarLayout.tsx
+++ b/src/components/Layout/NavbarLayout.tsx
@@ -1,0 +1,38 @@
+import { useQuery } from '@tanstack/react-query';
+import { getMyInfo } from 'src/apis/getMyInfo';
+import stroke from 'src/assets/images/stroke.svg';
+import DashboardMemebers from '../Navbar/DashboardMembers';
+import DashboardTitle from '../Navbar/DashboardTitle';
+import NavButtons from '../Navbar/NavButtons';
+import Profile from '../Profile/Profile';
+
+export default function Navbar() {
+  const { data } = useQuery({
+    queryKey: ['myInfo'],
+    queryFn: () => getMyInfo()
+  });
+
+  return (
+    <div className="flex items-center w-screen tablet:h-[7rem] h-[6rem] bg-white desktop:pl-[34rem] desktop:pr-[8rem] tablet:pr-[4rem] pr-[1.2rem] border border-b-gray_D9D9D9">
+      <div className="flex desktop:justify-between justify-end w-[100%]">
+        <DashboardTitle />
+        <div className="flex items-center desktop:gap-[3.2rem] tablet:gap-[2.4rem] gap-[1.2rem]">
+          <NavButtons />
+          <DashboardMemebers />
+          <img
+            src={stroke}
+            alt="세로 줄"
+            className="tablet:h-[3.8rem] h-[3.4rem]"
+          />
+          <Profile
+            size="basicSize"
+            border="white"
+            userName={data?.nickname}
+            profileImgSrc={data?.profileImageUrl}
+            isNameVisible="mobileInvisible"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Modal/Card/CardDetail.tsx
+++ b/src/components/Modal/Card/CardDetail.tsx
@@ -78,6 +78,7 @@ export default function CardDetail() {
           </span>
           <Profile
             size="smallSize"
+            border="none"
             profileImgSrc={cardInformation?.assignee.profileImageUrl}
             userName={cardInformation?.assignee.nickname}
           />

--- a/src/components/Modal/Card/CommentList.tsx
+++ b/src/components/Modal/Card/CommentList.tsx
@@ -35,6 +35,7 @@ export default function CommentList({
         <span className="flex justify-start">
           <Profile
             size="smallSize"
+            border="none"
             profileImgSrc={comment.author.profileImageUrl}
             userName={comment.author.nickname}
           />

--- a/src/components/Modal/InviteMember.tsx
+++ b/src/components/Modal/InviteMember.tsx
@@ -3,14 +3,15 @@ import ModalResetButton from '../Buttons/ModalResetButton';
 import ModalSubmitButton from '../Buttons/ModalSubmitButton';
 
 export default function InviteMember() {
-  const { handleFormSubmit, handleInputChange } = useInviteMember();
+  const { handleFormSubmit, handleInputChange, errorMessage } =
+    useInviteMember();
 
   return (
     <>
       <h2 className="text-[#333236] tablet:mb-[3.2rem] mb-[2.4rem] tablet:text-[2.4rem] text-[2rem] font-bold">
         초대하기
       </h2>
-      <form className="flex flex-col" onSubmit={handleFormSubmit}>
+      <form className="relative flex flex-col" onSubmit={handleFormSubmit}>
         <label
           className="tablet:text-[1.8rem] text-[1.6rem] text-[#333236] mb-[1rem] font-medium"
           htmlFor="inputId"
@@ -18,14 +19,19 @@ export default function InviteMember() {
           이메일
         </label>
         <input
-          className="tablet:w-[48.4rem] tablet:h-[4.8rem] w-[28.7rem] h-[4.2rem] border border-[#D9D9D9] bg-[#FFF] rounded-[0.6rem] px-[1.6rem] tablet:mb-[2.8rem] mb-[2.4rem] text-[#333236] outline-none placeholder:text-[#333236] tablet:text-[1.6rem] text-[1.4rem]"
+          className="tablet:w-[48.4rem] tablet:h-[4.8rem] w-[28.7rem] h-[4.2rem] border border-[#D9D9D9] bg-[#FFF] rounded-[0.6rem] px-[1.6rem] text-[#333236] outline-none placeholder:text-[#333236] tablet:text-[1.6rem] text-[1.4rem]"
           id="inputId"
           type="email"
           placeholder="codeit@codeit.com"
           onChange={e => handleInputChange(e)}
           required
         />
-        <div className="flex tablet:justify-end justify-center tablet:gap-[1.2rem] gap-[1.1rem]">
+        {errorMessage && (
+          <p className="text-red_D6173A text-[1.6rem] py-[1rem]">
+            {errorMessage}
+          </p>
+        )}
+        <div className="flex tablet:justify-end justify-center tablet:gap-[1.2rem] gap-[1.1rem] tablet:mt-[2.8rem] mt-[2.4rem]">
           <ModalResetButton>취소</ModalResetButton>
           <ModalSubmitButton>초대</ModalSubmitButton>
         </div>

--- a/src/components/Navbar/DashboardMembers.tsx
+++ b/src/components/Navbar/DashboardMembers.tsx
@@ -1,0 +1,83 @@
+import { Params, useParams } from 'react-router-dom';
+import getDashboardMembers from 'src/apis/getDashboardMembers';
+import { useQuery } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
+import Profile from '../Profile/Profile';
+
+export default function DashboardMemebers() {
+  const [visibleMembersCount, setVisibleMembersCount] = useState(4);
+  const [invisibleMembersCount, setInvisibleMembersCount] = useState(0);
+  const [isDesktopView, setIsDesktopView] = useState(true);
+  const { boardId } = useParams<Params>();
+
+  const { data } = useQuery({
+    queryKey: ['navDashboardMembers', boardId],
+    queryFn: () => getDashboardMembers(boardId)
+  });
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth >= 1200) {
+        // 데스크톱
+        setIsDesktopView(true);
+        setVisibleMembersCount(4);
+      } else {
+        // 태블릿, 모바일
+        setIsDesktopView(false);
+        setVisibleMembersCount(2);
+      }
+    };
+
+    // 컴포넌트 마운트 시 리사이즈 이벤트 리스너 추가
+    window.addEventListener('resize', handleResize);
+    handleResize();
+
+    // 축약 멤버 수 결정
+    const totalCount = data?.totalCount ?? 1;
+    setInvisibleMembersCount(totalCount - visibleMembersCount);
+
+    // 컴포넌트 언마운트 시 리사이즈 이벤트 리스너 제거
+    return () => window.removeEventListener('resize', handleResize);
+  }, [isDesktopView, data]);
+
+  return (
+    <div className="flex items-center tablet:ml-[0.8rem] ml-[0.4rem] desktop:w-[15.7rem] tablet:w-[9.7rem] w-[8.5rem]">
+      {data?.members.map((member, index) => (
+        <div className="relative">
+          {index < visibleMembersCount ? (
+            <div
+              key={member.id}
+              className="relative"
+              style={{
+                left: `${index * -8}px`,
+                zIndex: index + 1
+              }}
+            >
+              <Profile
+                size="basicSize"
+                profileImgSrc={member.profileImageUrl}
+                userName={member.nickname}
+                border="white"
+                isNameVisible="invisible"
+              />
+            </div>
+          ) : null}
+        </div>
+      ))}
+      {invisibleMembersCount > 0 ? (
+        <div
+          className="relative"
+          style={{
+            left: `${visibleMembersCount * -8}px`,
+            zIndex: visibleMembersCount + 1
+          }}
+        >
+          <div className="bg-pink_F4D7DA rounded-full  tablet:w-[3.8rem] tablet:h-[3.8rem] w-[3.4rem] h-[3.4rem] border border-[0.2rem] border-white" />
+          <span className="flex absolute transform -translate-x-1/2 -translate-y-1/2 top-1/2 left-1/2 tablet:text-[1.6rem] text-[1.4rem] font-medium text-red_D25B68">
+            +{invisibleMembersCount}
+          </span>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/Navbar/DashboardMembers.tsx
+++ b/src/components/Navbar/DashboardMembers.tsx
@@ -1,74 +1,36 @@
-import { Params, useParams } from 'react-router-dom';
-import getDashboardMembers from 'src/apis/getDashboardMembers';
-import { useQuery } from '@tanstack/react-query';
-import { useEffect, useState } from 'react';
+import useCalcVisibleMembers from 'src/hooks/useCalcVisibleMembers';
 import Profile from '../Profile/Profile';
 
 export default function DashboardMemebers() {
-  const [visibleMembersCount, setVisibleMembersCount] = useState(4);
-  const [invisibleMembersCount, setInvisibleMembersCount] = useState(0);
-  const [isDesktopView, setIsDesktopView] = useState(true);
-  const { boardId } = useParams<Params>();
-
-  const { data } = useQuery({
-    queryKey: ['navDashboardMembers', boardId],
-    queryFn: () => getDashboardMembers(boardId)
-  });
-
-  useEffect(() => {
-    const handleResize = () => {
-      if (window.innerWidth >= 1200) {
-        // 데스크톱
-        setIsDesktopView(true);
-        setVisibleMembersCount(4);
-      } else {
-        // 태블릿, 모바일
-        setIsDesktopView(false);
-        setVisibleMembersCount(2);
-      }
-    };
-
-    // 컴포넌트 마운트 시 리사이즈 이벤트 리스너 추가
-    window.addEventListener('resize', handleResize);
-    handleResize();
-
-    // 축약 멤버 수 결정
-    const totalCount = data?.totalCount ?? 1;
-    setInvisibleMembersCount(totalCount - visibleMembersCount);
-
-    // 컴포넌트 언마운트 시 리사이즈 이벤트 리스너 제거
-    return () => window.removeEventListener('resize', handleResize);
-  }, [isDesktopView, data]);
+  const { data, visibleMembersCount, invisibleMembersCount } =
+    useCalcVisibleMembers();
 
   return (
-    <div className="flex items-center tablet:ml-[0.8rem] ml-[0.4rem] desktop:w-[15.7rem] tablet:w-[9.7rem] w-[8.5rem]">
-      {data?.members.map((member, index) => (
+    <div className="flex items-center justify-end tablet:ml-[0.8rem] ml-[0.4rem] z-5">
+      {data?.members.slice(0, visibleMembersCount).map((member, index) => (
         <div className="relative">
-          {index < visibleMembersCount ? (
-            <div
-              key={member.id}
-              className="relative"
-              style={{
-                left: `${index * -8}px`,
-                zIndex: index + 1
-              }}
-            >
-              <Profile
-                size="basicSize"
-                profileImgSrc={member.profileImageUrl}
-                userName={member.nickname}
-                border="white"
-                isNameVisible="invisible"
-              />
-            </div>
-          ) : null}
+          <div
+            key={member.id}
+            className="relative"
+            style={{
+              marginRight: `${index - 10}px`,
+              zIndex: index + 1
+            }}
+          >
+            <Profile
+              size="basicSize"
+              profileImgSrc={member.profileImageUrl}
+              userName={member.nickname}
+              border="white"
+              isNameVisible="invisible"
+            />
+          </div>
         </div>
       ))}
       {invisibleMembersCount > 0 ? (
         <div
           className="relative"
           style={{
-            left: `${visibleMembersCount * -8}px`,
             zIndex: visibleMembersCount + 1
           }}
         >

--- a/src/components/Navbar/DashboardTitle.tsx
+++ b/src/components/Navbar/DashboardTitle.tsx
@@ -1,0 +1,25 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { Params, useParams } from 'react-router-dom';
+import crown from 'src/assets/images/crown.svg';
+import getDashboardDetails from 'src/apis/getDashboardDetails';
+
+export default function DashboardTitle() {
+  const { boardId } = useParams<Params>();
+  const { data } = useQuery({
+    queryKey: ['dashboardDetails', boardId],
+    queryFn: () => getDashboardDetails(boardId)
+  });
+
+  return (
+    <div className="items-center gap-[0.8rem] hidden desktop:flex">
+      <div className="text-[2rem] font-bold">{data?.title}</div>
+      {data?.createdByMe ? (
+        <img
+          className="w-[2rem] h-[1.6rem]"
+          src={crown}
+          alt="내가 만든 대시보드를 표시하는 크라운 이미지"
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/Navbar/NavButtons.tsx
+++ b/src/components/Navbar/NavButtons.tsx
@@ -1,0 +1,34 @@
+import setting from 'src/assets/images/setting.svg';
+import addBox from 'src/assets/images/add-box.svg';
+import Button from '../Buttons/Button';
+
+export default function NavButtons() {
+  return (
+    <div className="flex desktop:gap-[1.6rem] tablet:gap-[1.2rem] gap-[0.6rem] text-gray_787486">
+      <Button
+        variant="ghost"
+        type="button"
+        prefix={
+          <img src={setting} alt="톱니 이미지" className="hidden tablet:flex" />
+        }
+        customStyles="flex items-center text-[1.4rem] desktop:text-[1.6rem] font-medium gap-[0.8rem] tablet:rounded-[0.8rem] rounded-[0.6rem] px-[1.2rem] pt-[0.6rem] pb-[0.7rem] tablet:px-[1.6rem] tablet:pt-[0.8rem] tablet:pb-[0.9rem] desktop:py-[1rem] h-[3rem] tablet:h-[3.6rem] desktop:h-[4rem]"
+      >
+        관리
+      </Button>
+      <Button
+        variant="ghost"
+        type="button"
+        prefix={
+          <img
+            src={addBox}
+            alt="초대하기 더하기 아이콘"
+            className="hidden tablet:flex"
+          />
+        }
+        customStyles="flex justify-center items-center text-[1.4rem] desktop:text-[1.6rem] font-medium gap-[0.8rem] tablet:rounded-[0.8rem] rounded-[0.6rem] px-[1.2rem] pt-[0.6rem] pb-[0.7rem] tablet:px-[1.6rem] tablet:pt-[0.8rem] tablet:pb-[0.9rem] desktop:py-[1rem] h-[3rem] tablet:h-[3.6rem] desktop:h-[4rem]"
+      >
+        초대하기
+      </Button>
+    </div>
+  );
+}

--- a/src/components/Navbar/NavButtons.tsx
+++ b/src/components/Navbar/NavButtons.tsx
@@ -1,13 +1,21 @@
 import setting from 'src/assets/images/setting.svg';
 import addBox from 'src/assets/images/add-box.svg';
+import { useSetAtom } from 'jotai';
+import { modalAtom } from 'src/store/store';
+import { Params, useNavigate, useParams } from 'react-router-dom';
 import Button from '../Buttons/Button';
 
 export default function NavButtons() {
+  const setModal = useSetAtom(modalAtom);
+  const navigate = useNavigate();
+  const { boardId } = useParams<Params>();
+
   return (
     <div className="flex desktop:gap-[1.6rem] tablet:gap-[1.2rem] gap-[0.6rem] text-gray_787486">
       <Button
         variant="ghost"
         type="button"
+        onClick={() => navigate(`/dashboard/${boardId}/edit`)}
         prefix={
           <img src={setting} alt="톱니 이미지" className="hidden tablet:flex" />
         }
@@ -18,6 +26,13 @@ export default function NavButtons() {
       <Button
         variant="ghost"
         type="button"
+        onClick={() =>
+          setModal(prev => ({
+            ...prev,
+            name: 'inviteMember',
+            status: true
+          }))
+        }
         prefix={
           <img
             src={addBox}

--- a/src/components/Profile/Profile.tsx
+++ b/src/components/Profile/Profile.tsx
@@ -4,7 +4,25 @@ interface ProfileProps {
   profileImgSrc?: string | null;
   userName?: string;
   size: 'basicSize' | 'smallSize';
+  border: 'white' | 'none';
+  isNameVisible?:
+    | 'visible'
+    | 'invisible'
+    | 'mobileInvisible'
+    | 'tabletInvisible';
 }
+
+const userNameVisible = {
+  visible: '',
+  invisible: 'hidden',
+  mobileInvisible: 'hidden tablet:flex',
+  tabletInvisible: 'hidden desktop:flex'
+};
+
+const borderColor = {
+  white: 'border border-[0.2rem] border-white',
+  none: ''
+};
 
 const profile = {
   basicSize: 'tablet:w-[3.8rem] tablet:h-[3.8rem] w-[3.4rem] h-[3.4rem]',
@@ -18,7 +36,9 @@ const text = {
 export default function Profile({
   profileImgSrc,
   userName,
-  size = 'basicSize'
+  size = 'basicSize',
+  border = 'none',
+  isNameVisible = 'visible'
 }: ProfileProps) {
   const [randomBgColor, setRandomBgColor] = useState('');
   const firstLetterOfNickName = userName?.charAt(0).toUpperCase();
@@ -40,14 +60,14 @@ export default function Profile({
       <div className="relative">
         {profileImgSrc ? (
           <img
-            className={`rounded-full ${profile[size]}`}
+            className={`rounded-full ${profile[size]} ${borderColor[border]}`}
             src={profileImgSrc}
             alt="프로필 이미지"
           />
         ) : (
           <>
             <div
-              className={`${randomBgColor} rounded-full  ${profile[size]}`}
+              className={`${randomBgColor} rounded-full  ${profile[size]}  ${borderColor[border]}`}
             />
             <span
               className={`absolute transform -translate-x-1/2 -translate-y-1/2 top-1/2 left-1/2 ${text[size]} font-semibold text-white`}
@@ -57,9 +77,11 @@ export default function Profile({
           </>
         )}
       </div>
-      {userName ? (
-        <span className="tablet:text-[1.6rem] text-[1.4rem]">{userName}</span>
-      ) : null}
+      <span
+        className={`tablet:text-[1.6rem] text-[1.4rem] ${userNameVisible[isNameVisible]}`}
+      >
+        {userName}
+      </span>
     </div>
   );
 }

--- a/src/hooks/useCalcVisibleMembers.ts
+++ b/src/hooks/useCalcVisibleMembers.ts
@@ -1,0 +1,43 @@
+import { useQuery } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
+import { Params, useParams } from 'react-router-dom';
+import getDashboardMembers from 'src/apis/getDashboardMembers';
+
+export default function useCalcVisibleMembers() {
+  const [visibleMembersCount, setVisibleMembersCount] = useState(4);
+  const [invisibleMembersCount, setInvisibleMembersCount] = useState(0);
+  const [isDesktopView, setIsDesktopView] = useState(true);
+  const { boardId } = useParams<Params>();
+
+  const { data } = useQuery({
+    queryKey: ['navDashboardMembers', boardId],
+    queryFn: () => getDashboardMembers(boardId)
+  });
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth >= 1200) {
+        // 데스크톱
+        setIsDesktopView(true);
+        setVisibleMembersCount(4);
+      } else {
+        // 태블릿, 모바일
+        setIsDesktopView(false);
+        setVisibleMembersCount(2);
+      }
+    };
+
+    // 컴포넌트 마운트 시 리사이즈 이벤트 리스너 추가
+    window.addEventListener('resize', handleResize);
+    handleResize();
+
+    // 축약 멤버 수 결정
+    const totalCount = data?.totalCount ?? 1;
+    setInvisibleMembersCount(totalCount - visibleMembersCount);
+
+    // 컴포넌트 언마운트 시 리사이즈 이벤트 리스너 제거
+    return () => window.removeEventListener('resize', handleResize);
+  }, [isDesktopView, data]);
+
+  return { data, visibleMembersCount, invisibleMembersCount };
+}

--- a/src/hooks/useInviteMember.ts
+++ b/src/hooks/useInviteMember.ts
@@ -35,7 +35,6 @@ export default function useInviteMember() {
     },
 
     onError: error => {
-      console.log(error);
       if (axios.isAxiosError(error)) {
         setErrorMessage(error?.response?.data.message);
       }

--- a/src/hooks/useInviteMember.ts
+++ b/src/hooks/useInviteMember.ts
@@ -1,15 +1,23 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import axios from 'axios';
 import { useSetAtom } from 'jotai';
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent, FormEvent, useState } from 'react';
 import { Params, useParams } from 'react-router-dom';
+import getDashboardInvitations from 'src/apis/getDashboardInvitations';
 import postDashboardInvitations from 'src/apis/postDashboardInvitation';
 import { modalAtom } from 'src/store/store';
 
 export default function useInviteMember() {
   const [inputValue, setInputValue] = useState('');
+  const [errorMessage, setErrorMessage] = useState<string>('');
   const { boardId } = useParams<Params>();
   const queryClient = useQueryClient();
   const setModal = useSetAtom(modalAtom);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['invitations', boardId],
+    queryFn: () => getDashboardInvitations(boardId)
+  });
 
   const { mutate, isPending } = useMutation({
     mutationFn: ({ email }: { email: string }) =>
@@ -19,6 +27,18 @@ export default function useInviteMember() {
       queryClient.refetchQueries({
         queryKey: ['invitations', boardId]
       });
+      setModal(prev => ({
+        ...prev,
+        name: 'inviteMember',
+        status: false
+      }));
+    },
+
+    onError: error => {
+      console.log(error);
+      if (axios.isAxiosError(error)) {
+        setErrorMessage(error?.response?.data.message);
+      }
     }
   });
 
@@ -26,17 +46,24 @@ export default function useInviteMember() {
     setInputValue(e.target.value);
   };
 
-  const handleFormSubmit = () => {
-    if (isPending) {
+  const handleFormSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (isPending || isLoading) {
       return;
     }
+
+    if (
+      data?.invitations.some(
+        invitation => invitation.invitee.email === inputValue
+      )
+    ) {
+      setErrorMessage('이미 초대 요청을 보낸 유저입니다.');
+      return;
+    }
+    setErrorMessage('');
+
     mutate({ email: inputValue });
-    setModal(prev => ({
-      ...prev,
-      name: 'inviteMember',
-      status: false
-    }));
   };
 
-  return { handleInputChange, handleFormSubmit };
+  return { handleInputChange, handleFormSubmit, errorMessage };
 }

--- a/src/hooks/usePagenationDashboardMembers.ts
+++ b/src/hooks/usePagenationDashboardMembers.ts
@@ -13,7 +13,8 @@ export const usePagenationDashboardMembers = () => {
 
   const { data, isLoading } = useQuery({
     queryKey: ['dashboardMembers', boardId, nowPage],
-    queryFn: () => getDashboardMembers(boardId, nowPage)
+    queryFn: () =>
+      getDashboardMembers(boardId, nowPage, PAGENATION_SIZE.DASHBOARD.MEMBERS)
   });
 
   const { mutate, isPending } = useMutation({
@@ -23,6 +24,9 @@ export const usePagenationDashboardMembers = () => {
     onSuccess: () => {
       queryClient.refetchQueries({
         queryKey: ['dashboardMembers', boardId, nowPage]
+      });
+      queryClient.refetchQueries({
+        queryKey: ['navDashboardMembers', boardId]
       });
     }
   });

--- a/src/hooks/useUpdateDashboardTitle.ts
+++ b/src/hooks/useUpdateDashboardTitle.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import getDashboardDetails from 'src/apis/getDashboardDetails';
 import putDashboardTitle from 'src/apis/putDashboardTitle';
+import { usePagenationDashboardList } from './usePagenationDashboardList';
 
 export const useUpdateDashboardTitle = (boardId: string | undefined) => {
   const queryClient = useQueryClient();
@@ -21,8 +22,11 @@ export const useUpdateDashboardTitle = (boardId: string | undefined) => {
     }) => putDashboardTitle(dashboardId, title, color),
 
     onSuccess: () => {
-      queryClient.invalidateQueries({
+      queryClient.refetchQueries({
         queryKey: ['dashboards']
+      });
+      queryClient.refetchQueries({
+        queryKey: ['dashboardDetails', boardId]
       });
     },
 

--- a/src/types/memberTypes.ts
+++ b/src/types/memberTypes.ts
@@ -1,12 +1,12 @@
 export interface MemberData {
   id: number;
-  userId: number;
+  userId?: number;
   email: string;
   nickname: string;
   profileImageUrl: string;
   createdAt: Date;
   updatedAt: Date;
-  isOwner: boolean;
+  isOwner?: boolean;
 }
 
 export interface MemberList {

--- a/src/utils/handleError.ts
+++ b/src/utils/handleError.ts
@@ -3,7 +3,6 @@ import axios from 'axios';
 export default function handleError(error: unknown) {
   if (axios.isAxiosError(error)) {
     console.log(error.message);
-    alert(error.response?.data?.message);
     throw error;
   }
   if (error instanceof Error) {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -35,7 +35,9 @@ module.exports = {
         skyblue_9DD7ED: '#9DD7ED',
         yellow_FDD446: '#FDD446',
         yellow_FFC85A: '#FFC85A',
-        khaki_A3C4A2: '#A3C4A2'
+        khaki_A3C4A2: '#A3C4A2',
+        pink_F4D7DA: '#F4D7DA',
+        red_D25B68: '#D25B68'
       }
     }
   },


### PR DESCRIPTION
[PR 규칙](https://www.notion.so/PR-rules-e68d631e586948478a5fa8408a464b92)

### 주요 변경사항

- Navbar 구현
- 반응형 적용
- 관리 버튼 클릭 시 대시보드 수정 페이지(`/dashboard/:boardId/edit`)로 이동합니다.
- 초대하기 버튼 클릭 시 초대하기 모달이 나타납니다.
- 멤버 수 표시 
  - 데스크탑 최대 4명 + 나머지 인원수
  - 모바일/태블릿 최대 2명 + 나머지 인원수
- 초대하기 모달
  - 모달에 에러 메세지 표시 기능 추가
  - 중복 초대 불가하게 구현
  
### 리뷰어에게

- api 파일 중 `getDashboardMembers` 함수에서 `size`를 prop으로 받도록 변경하였습니다. 참고해주시면 감사하겠습니다.

### 스크린샷
![스크린샷 2024-03-24 오전 1 43 02](https://github.com/Codeit-Part3-Taskify/Taskify/assets/98401099/2d165d28-563a-46c0-9c48-7bf204878bdd)
![스크린샷 2024-03-24 오전 1 43 17](https://github.com/Codeit-Part3-Taskify/Taskify/assets/98401099/d461cc37-547a-434a-9895-ad75e86447e7)
![스크린샷 2024-03-24 오전 1 43 26](https://github.com/Codeit-Part3-Taskify/Taskify/assets/98401099/3c5f69aa-447a-49b1-9f0e-8ee849617d98)

초대하기 모달
![스크린샷 2024-03-24 오전 4 34 02](https://github.com/Codeit-Part3-Taskify/Taskify/assets/98401099/07edd94e-7f2b-4dae-a42d-260a147ae00b)
![스크린샷 2024-03-24 오전 4 34 09](https://github.com/Codeit-Part3-Taskify/Taskify/assets/98401099/240737cf-5bb2-4def-80fe-499b12f29e1d)

### 이슈

> close할 이슈 또는 관련 이슈

- closed: #41
- related: #
