### PR TITLE
Feat: 초대받은 대시보드 검색어 필터링 

### DIFF
--- a/src/apis/getMyInvitations.ts
+++ b/src/apis/getMyInvitations.ts
@@ -2,13 +2,13 @@ import { InvitationsResponse } from 'src/types/invitationsTypes';
 import axios from './axiosInstance';
 
 const getMyInvitations = async (
-  size?: number,
-  title?: string
+  title?: string,
+  size?: number
 ): Promise<InvitationsResponse> => {
   const { data } = await axios.get<InvitationsResponse>('invitations', {
     params: {
-      size,
-      title
+      title,
+      size
     }
   });
 

--- a/src/components/Dashboard/MyDashboard/Invitations.tsx
+++ b/src/components/Dashboard/MyDashboard/Invitations.tsx
@@ -17,7 +17,7 @@ export default function Invitations() {
 
       {invitations.length ? (
         <>
-          <div className="flex items-center w-[22.8rem] h-[3.6rem] border-solid border-[0.1rem] rounded-[0.6rem] ml-[1.6rem] mt-[2rem] px-[1.2rem] tablet:ml-[2.8rem] tablet:w-[44.8rem] tablet:h-[4rem]">
+          <div className="flex items-center w-[22.8rem] h-[3.6rem] border-solid border-[0.1rem] rounded-[0.6rem] ml-[1.6rem] mt-[2rem] px-[1.2rem] tablet:ml-[2.8rem] tablet:w-[44.8rem] tablet:h-[4rem] desktop:w-[96.6rem]">
             <img src={search} alt="돋보기" className="w-[2.2rem] h-[2.2rem]" />
             <input
               type="text"

--- a/src/components/Dashboard/MyDashboard/Invitations.tsx
+++ b/src/components/Dashboard/MyDashboard/Invitations.tsx
@@ -5,8 +5,7 @@ import { Invitation } from 'src/types/invitationsTypes';
 import InvitationsItem from './InvitationsItem';
 
 export default function Invitations() {
-  const data = useMyInvations();
-
+  const { data, onSubmit } = useMyInvations();
   const invitations = data?.invitations ?? [];
 
   return (
@@ -17,14 +16,21 @@ export default function Invitations() {
 
       {invitations.length ? (
         <>
-          <div className="flex items-center w-[22.8rem] h-[3.6rem] border-solid border-[0.1rem] rounded-[0.6rem] ml-[1.6rem] mt-[2rem] px-[1.2rem] tablet:ml-[2.8rem] tablet:w-[44.8rem] tablet:h-[4rem] desktop:w-[96.6rem]">
-            <img src={search} alt="돋보기" className="w-[2.2rem] h-[2.2rem]" />
-            <input
-              type="text"
-              placeholder="검색"
-              className="w-full text-[1.4rem] ml-[1rem]"
-            />
-          </div>
+          <form onSubmit={onSubmit}>
+            <div className="flex items-center w-[22.8rem] h-[3.6rem] border-solid border-[0.1rem] rounded-[0.6rem] ml-[1.6rem] mt-[2rem] px-[1.2rem] tablet:ml-[2.8rem] tablet:w-[44.8rem] tablet:h-[4rem] desktop:w-[96.6rem]">
+              <img
+                src={search}
+                alt="돋보기"
+                className="w-[2.2rem] h-[2.2rem]"
+              />
+              <input
+                name="search"
+                type="text"
+                placeholder="검색"
+                className="w-full text-[1.4rem] ml-[1rem]"
+              />
+            </div>
+          </form>
 
           {invitations.map((invitation: Invitation) => (
             <InvitationsItem key={invitation.id} invitation={invitation} />

--- a/src/components/Dashboard/MyDashboard/InvitationsItem.tsx
+++ b/src/components/Dashboard/MyDashboard/InvitationsItem.tsx
@@ -12,30 +12,35 @@ export default function InvitationsItem({ invitation }: InvitationsItemProps) {
 
   return (
     <section className="mt-[0.8rem]">
-      <div className="border-b-[0.1rem]">
-        <div className="flex flex-col gap-[1rem]">
-          <div className="px-[1.6rem] text-[1.4rem] mt-[0.8rem]">
+      <div className="border-b-[0.1rem] tablet:flex">
+        <div className="flex flex-col gap-[1rem] tablet:flex-row tablet:items-center">
+          <div className="px-[1.6rem] text-[1.4rem] mt-[0.8rem] flex tablet:flex-col tablet:text-[1.6rem] tablet:m-0 tablet:gap-[2rem] tablet:px-[3rem] desktop:w-[35rem]">
             <span className="text-gray_9FA6B2 mr-[2.8rem]">이름</span>
             <span>{invitation.dashboard.title}</span>
           </div>
-          <div className="px-[1.6rem] text-[1.4rem]">
+          <div className="px-[1.6rem] text-[1.4rem] flex tablet:flex-col tablet:text-[1.6rem] tablet:gap-[2rem] desktop:w-[35rem]">
             <span className="text-gray_9FA6B2 mr-[1.6rem]">초대자</span>
             <span>{invitation.inviter.nickname}</span>
           </div>
         </div>
-        <div className="p-[1.6rem] flex gap-[1rem] text-[1.2rem]">
-          <button
-            onClick={acceptInvitation}
-            className="w-[10.9rem] h-[2.8rem] bg-violet rounded-[0.4rem] text-white"
-          >
-            수락
-          </button>
-          <button
-            onClick={rejectInvitation}
-            className="w-[10.9rem] h-[2.8rem] bg-white rounded-[0.4rem] text-violet border-solid border-[0.1rem]"
-          >
-            거절
-          </button>
+        <div className="p-[1.6rem] flex gap-[1rem] text-[1.2rem] tablet:text-[1.4rem] tablet:flex-col tablet:gap-[1.5rem]">
+          <span className="text-gray_9FA6B2 mobile:hidden tablet:inline-block tablet:text-[1.6rem]">
+            수락 여부
+          </span>
+          <div className="flex gap-[1rem]">
+            <button
+              onClick={acceptInvitation}
+              className="w-[10.9rem] h-[2.8rem] bg-violet rounded-[0.4rem] text-white tablet:w-[7.2rem] tablet:h-[3rem] desktop:w-[8.4rem] desktop:h-[3.2rem]"
+            >
+              수락
+            </button>
+            <button
+              onClick={rejectInvitation}
+              className="w-[10.9rem] h-[2.8rem] bg-white rounded-[0.4rem] text-violet border-solid border-[0.1rem] tablet:w-[7.2rem] tablet:h-[3rem] desktop:w-[8.4rem] desktop:h-[3.2rem]"
+            >
+              거절
+            </button>
+          </div>
         </div>
       </div>
     </section>

--- a/src/components/Layout/SideBarLayout.tsx
+++ b/src/components/Layout/SideBarLayout.tsx
@@ -4,7 +4,7 @@ import LogoText from '../Sidebar/LogoText';
 
 export default function Sidebar() {
   return (
-    <aside className="w-[6.7rem] min-h-screen border-r-[0.1rem] border-gray_D9D9D9 flex-col flex-shrink-0 pt-[2rem] tablet:w-[16rem] desktop:w-[30rem] desktop:px-[2.4rem] bg-white">
+    <aside className="w-[6.7rem] min-h-screen border-r-[0.1rem] border-gray_D9D9D9 pt-[2rem] tablet:w-[16rem] desktop:w-[30rem] desktop:px-[2.4rem] bg-white">
       <div className="sticky top-[2rem] left-0">
         <LogoText />
         <AddDashboardHeader />

--- a/src/components/Sidebar/LogoText.tsx
+++ b/src/components/Sidebar/LogoText.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 
 export default function LogoText() {
   return (
-    <Link to="/">
+    <Link to="/mydashboard">
       <div className="mb-[3.8rem] cursor-pointer flex items-center justify-center tablet:mb-[6rem] desktop:justify-start">
         <img
           className="w-[2.3rem] h-[2.7rem]"

--- a/src/hooks/useMyInvations.ts
+++ b/src/hooks/useMyInvations.ts
@@ -1,13 +1,40 @@
-import { useQuery } from '@tanstack/react-query';
+import { FormEvent, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import getMyInvitations from 'src/apis/getMyInvitations';
 
 export default function useMyInvations() {
+  const [resultValue, setResultValue] = useState('');
+  const queryClient = useQueryClient();
+
+  const { mutate } = useMutation({
+    mutationFn: (value: string) => getMyInvitations(value),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['myInvitations']
+      });
+    }
+  });
+
+  const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+    const searchValue = formData.get('search') as string;
+
+    setResultValue(searchValue);
+    mutate(searchValue);
+  };
+
   const { data, isError } = useQuery({
-    queryKey: ['myInvitations'],
-    queryFn: () => getMyInvitations()
+    queryKey: ['myInvitations', resultValue || 'myInvitations'],
+    queryFn: () => {
+      if (resultValue) {
+        return getMyInvitations(resultValue);
+      }
+      return getMyInvitations();
+    }
   });
 
   if (isError) alert('내 초대내역을 불러오지 못했습니다.');
 
-  return data;
+  return { data, onSubmit };
 }


### PR DESCRIPTION
[PR 규칙](https://www.notion.so/PR-rules-e68d631e586948478a5fa8408a464b92)

### 리뷰어에게

- 나의 대시보드 페이지로 가는 버튼이 없어서, 로고 클릭 시 이동하게 변경했습니다.
- 미구현 : 초대받은 대시보드 리스트 무한 스크롤
- 해결 못함: 사이드바 세로 크기

### 주요 변경사항

- 초대받은 대시보드 검색어 필터링 
- 무한 스크롤 제외하고 나의 대시보드 페이지는 다 구현했습니다.

### 스크린샷

![검색필터](https://github.com/Codeit-Part3-Taskify/Taskify/assets/72595163/98b60f57-4e2e-4d7d-b480-2858afe57aee)

### 이슈

> close할 이슈 또는 관련 이슈

- closed: #1 
- related: #
